### PR TITLE
Fix pr ci retrigger

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ on:
     branches: [development]
     paths-ignore:
       - '**.md'  # Exclude docs-only changes
-    if: "!contains(github.event.commits[0].message, 'Merge pull request')"
+    if: "github.event.commits && !contains(github.event.commits[0].message, 'Merge pull request')"
 
   workflow_dispatch:
 
@@ -18,6 +18,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && 
+       github.event.commits &&
        !contains(github.event.commits[0].message, 'Merge pull request'))
 
     runs-on: ubuntu-latest
@@ -50,17 +51,16 @@ jobs:
           --health-retries=10
 
     steps:
-      - name: Debug Event
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Debug Event Info
         run: |
           echo "EVENT TYPE: ${{ github.event_name }}"
           echo "REF: ${{ github.ref }}"
-          echo "IS PR EVENT: ${{ github.event.pull_request != '' }}"
-          echo "COMMIT MSG: ${{ toJson(github.event.commits[0].message) || 'N/A' }}"
-          echo "IS FORCED PUSH: ${{ github.event.forced }}"
-          echo "COMMIT COUNT: ${{ github.event.commits|length }}"
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          echo "COMMIT COUNT: ${{ github.event.commits && github.event.commits.length || 0 }}"
+          echo "FIRST COMMIT MSG: ${{ github.event.commits && github.event.commits[0].message || 'N/A' }}"
+          echo "IS PR: ${{ github.event.pull_request != '' }}"
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5


### PR DESCRIPTION
fix(ci): ensure PR CI Pipeline runs correctly for development PRs

- Remove problematic `!github.event.forced` check that blocked PR triggers
- Add explicit PR event types (opened/synchronize/reopened/ready_for_review)
- Implement job-level conditional for reliable execution:
  - Always runs for legitimate PR events
  - Blocks merge commits from triggering workflows
- Improve debugging output for future maintenance