### PR TITLE
My properties endpoint

### DIFF
--- a/apps/properties/tests/property_api_tests.py
+++ b/apps/properties/tests/property_api_tests.py
@@ -27,6 +27,7 @@ class TestPropertyAPI(TestSetUp):
             "apps.properties:properties-get-create-property-form-data"
         )
         cls.property_count_url: str = reverse("apps.properties:properties-count")
+        cls.my_properties_url: str = reverse("apps.properties:properties-my-properties")
 
     def setUp(self) -> None:
         super().setUp()
@@ -334,6 +335,19 @@ class TestPropertyAPI(TestSetUp):
         )
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data["count"], sold_properties_count)
+
+    def test_retrieve_my_property(self):
+        self.client.force_authenticate(user=self.user)
+
+        payload = {**self.property_payload}
+        res = self.client.post(self.list_url, data=payload)
+        self.assertEqual(res.status_code, 201)
+        res = self.client.post(self.list_url, data=payload)
+        self.assertEqual(res.status_code, 201)
+
+        res = self.client.get(self.my_properties_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 2)
 
     def tearDown(self) -> None:
         return super().tearDown()

--- a/apps/properties/tests/property_api_tests.py
+++ b/apps/properties/tests/property_api_tests.py
@@ -337,12 +337,19 @@ class TestPropertyAPI(TestSetUp):
         self.assertEqual(res.data["count"], sold_properties_count)
 
     def test_retrieve_my_property(self):
+        """Get my properties list.
+
+        Get the list without providing any country code and all the properties
+        from different countries shall be sent back.
+        """
         self.client.force_authenticate(user=self.user)
 
         payload = {**self.property_payload}
         res = self.client.post(self.list_url, data=payload)
         self.assertEqual(res.status_code, 201)
-        res = self.client.post(self.list_url, data=payload)
+        second = dict(payload)
+        second["country_code"] = "DK"
+        res = self.client.post(self.list_url, data=second)
         self.assertEqual(res.status_code, 201)
 
         res = self.client.get(self.my_properties_url)


### PR DESCRIPTION
A separate endpoint for my properties  is needed because the properties viewset queryset method forces the existence of `country_code`.
But if a user has loaded / created properties in different countries then they won’t be returned by using the ordinary api which returns properties from only one country.
