### PR TITLE
Added favorite_id on property detail response.

### DIFF
--- a/apps/properties/querysets/__init__.py
+++ b/apps/properties/querysets/__init__.py
@@ -1,5 +1,6 @@
-from .property import property_list_queryset
+from .property import property_detail_queryset, property_list_queryset
 
 __all__ = [
+    "property_detail_queryset",
     "property_list_queryset",
 ]

--- a/apps/properties/serializers/property.py
+++ b/apps/properties/serializers/property.py
@@ -19,6 +19,14 @@ from .property_image import (
 
 class PropertySerializer(ModelSerializer[Property]):
     property_images = PropertyImageSerializer(many=True, required=False)
+    favorite_id = IntegerField(
+        read_only=True,
+        allow_null=True,
+        help_text=_(
+            "ID of the favorite entry for the authenticated user. "
+            "Null if not favorited. Use this ID to delete the favorite.",
+        ),
+    )
 
     class Meta:
         model = Property

--- a/apps/properties/tests/property_api_tests.py
+++ b/apps/properties/tests/property_api_tests.py
@@ -28,6 +28,7 @@ class TestPropertyAPI(TestSetUp):
         )
         cls.property_count_url: str = reverse("apps.properties:properties-count")
         cls.my_properties_url: str = reverse("apps.properties:properties-my-properties")
+        cls.favorite_url: str = reverse("apps.favorites:favorite-list")
 
     def setUp(self) -> None:
         super().setUp()
@@ -142,6 +143,21 @@ class TestPropertyAPI(TestSetUp):
         self.assertEqual(res.data["price"], 50000)
         self.assertEqual(res.data["price_currency"], "Euro")
         prop.delete()
+
+    def test_favorite_id_annotation(self) -> None:
+        property = self.create_property()
+        url: str = reverse(self.detail_url, kwargs={"pk": property.id})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertIsNone(res.data["favorite_id"])
+        self.client.force_authenticate(user=self.user)
+        fav_payload = {"property_id": property.id}
+        res = self.client.post(self.favorite_url, fav_payload)
+        self.assertEqual(res.status_code, 201)
+        fav_id = res.data["id"]
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["favorite_id"], fav_id)
 
     def test_get_create_property_form_data(self) -> None:
         self.client.force_authenticate(user=self.user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ djangorestframework==3.16.0
 gunicorn==23.0.0
 pillow==11.3.0
 psycopg2-binary==2.9.10
-djangorestframework-simplejwt==5.5.0
+djangorestframework-simplejwt>=5.5.0,<5.6
 django-allauth==65.9.0
 dj-rest-auth[with_social]==7.0.1
 drf-spectacular==0.28.0


### PR DESCRIPTION
Updated property retrieve queryset by adding favorite_id on the detail response. This will ensure that the user can update favorite from a property detail page.